### PR TITLE
updated to 2.0.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>life.genny</groupId>
 	<artifactId>bridge</artifactId>
-	<version>2.0.1</version>
+	<version>2.0.2</version>
 	<name>bridge</name>
 	<properties>
 		<qwanda-utils.version>${version}</qwanda-utils.version>


### PR DESCRIPTION
Release 2.0.2.

### Changelog

Docker build files were fixed up so the jar file name is not hardwired to the version being built.